### PR TITLE
Added total number of results display for the most recent query

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -26,10 +26,10 @@ export default new Vuex.Store({
       state.totalNumberOfResults = null
       const collection = state.connection.db.collection(state.collectionName)
       const cursor = await collection.find(query)
-      cursor.count((err,result)=>{
-        if (err == null){
-          state.totalNumberOfResults = result
-        }
+      cursor.count((err,result) => {
+        if (err) return
+
+        state.totalNumberOfResults = result
       })
       state.records = await cursor.toArray()
     },

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -9,7 +9,8 @@ export default new Vuex.Store({
     connection: null,
     collections: [],
     records: [],
-    collectionName: ''
+    collectionName: '',
+    totalNumberOfResults: null
   },
   mutations: {},
   actions: {
@@ -23,7 +24,9 @@ export default new Vuex.Store({
     },
     async find({ state }, query = {}) {
       const collection = state.connection.db.collection(state.collectionName)
-      state.records = await collection.find(query).toArray()
+      const cursor = await collection.find(query)
+      state.totalNumberOfResults = await cursor.count()
+      state.records = await cursor.toArray()
     },
     async setCollection({ state }, collectionName) {
       state.collectionName = collectionName

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -23,9 +23,14 @@ export default new Vuex.Store({
       state.collections = await state.connection.db.listCollections().toArray()
     },
     async find({ state }, query = {}) {
+      state.totalNumberOfResults = null
       const collection = state.connection.db.collection(state.collectionName)
       const cursor = await collection.find(query)
-      state.totalNumberOfResults = await cursor.count()
+      cursor.count((err,result)=>{
+        if (err == null){
+          state.totalNumberOfResults = result
+        }
+      })
       state.records = await cursor.toArray()
     },
     async setCollection({ state }, collectionName) {

--- a/src/views/connection.vue
+++ b/src/views/connection.vue
@@ -34,7 +34,7 @@ export default {
       .record-views
         json-viewer(v-for="record in records" :value="record" theme="jv-dark")
     div.query-total-results
-      p(v-if="totalNumberOfResults!= null") Total Results: {{totalNumberOfResults}}
+      p(v-if="totalNumberOfResults != null") Total Results: {{totalNumberOfResults}}
 </template>
 
 <style lang="scss" scoped>

--- a/src/views/connection.vue
+++ b/src/views/connection.vue
@@ -5,7 +5,8 @@ export default {
   name: 'Connection',
   data() {
     return {
-      queryJson: '{}'
+      queryJson: '{}',
+      showTotalNumberOfResults: false
     }
   },
   computed: {
@@ -14,7 +15,9 @@ export default {
   methods: {
     ...mapActions(['find']),
     doQuery() {
+      this.showTotalNumberOfResults = false
       this.find(JSON.parse(this.queryJson))
+      this.showTotalNumberOfResults = true
     }
   }
 }
@@ -33,6 +36,8 @@ export default {
       h1 Records
       .record-views
         json-viewer(v-for="record in records" :value="record" theme="jv-dark")
+    div.query-total-results
+      p(v-if="showTotalNumberOfResults") Total Results: {{records.length}}
 </template>
 
 <style lang="scss" scoped>
@@ -41,6 +46,12 @@ export default {
   padding-right: 2rem;
   display: flex;
   flex-direction: column;
+}
+
+.query-total-results {
+  height: 1.4rem;
+  bottom: 1rem;
+  font-size: 1rem;
 }
 
 .records {

--- a/src/views/connection.vue
+++ b/src/views/connection.vue
@@ -10,13 +10,13 @@ export default {
     }
   },
   computed: {
-    ...mapState(['collectionName', 'records'])
+    ...mapState(['collectionName', 'records', 'totalNumberOfResults'])
   },
   methods: {
     ...mapActions(['find']),
-    doQuery() {
+    async doQuery() {
       this.showTotalNumberOfResults = false
-      this.find(JSON.parse(this.queryJson))
+      await this.find(JSON.parse(this.queryJson))
       this.showTotalNumberOfResults = true
     }
   }
@@ -37,7 +37,7 @@ export default {
       .record-views
         json-viewer(v-for="record in records" :value="record" theme="jv-dark")
     div.query-total-results
-      p(v-if="showTotalNumberOfResults") Total Results: {{records.length}}
+      p(v-if="showTotalNumberOfResults") Total Results: {{totalNumberOfResults}}
 </template>
 
 <style lang="scss" scoped>

--- a/src/views/connection.vue
+++ b/src/views/connection.vue
@@ -1,23 +1,26 @@
 <script>
-import { mapActions, mapState } from 'vuex'
+import { mapActions, mapState } from "vuex";
 
 export default {
-  name: 'Connection',
+  name: "Connection",
   data() {
     return {
-      queryJson: '{}'
-    }
+      queryJson: "{}",
+      showTotalNumberOfResults: false
+    };
   },
   computed: {
-    ...mapState(['collectionName', 'records'])
+    ...mapState(["collectionName", "records"])
   },
   methods: {
-    ...mapActions(['find']),
+    ...mapActions(["find"]),
     doQuery() {
-      this.find(JSON.parse(this.queryJson))
+      this.showTotalNumberOfResults = false;
+      this.find(JSON.parse(this.queryJson));
+      this.showTotalNumberOfResults = true;
     }
   }
-}
+};
 </script>
 <template lang="pug">
   div.connection
@@ -33,6 +36,8 @@ export default {
       h1 Records
       .record-views
         json-viewer(v-for="record in records" :value="record" theme="jv-dark")
+    div.query-total-results
+      p(v-if="showTotalNumberOfResults") Total Results: {{records.length}}
 </template>
 
 <style lang="scss" scoped>
@@ -41,6 +46,12 @@ export default {
   padding-right: 2rem;
   display: flex;
   flex-direction: column;
+}
+
+.query-total-results {
+  height: 1.4rem;
+  bottom: 1rem;
+  font-size: 1rem;
 }
 
 .records {

--- a/src/views/connection.vue
+++ b/src/views/connection.vue
@@ -6,7 +6,6 @@ export default {
   data() {
     return {
       queryJson: '{}',
-      showTotalNumberOfResults: false
     }
   },
   computed: {
@@ -15,9 +14,7 @@ export default {
   methods: {
     ...mapActions(['find']),
     async doQuery() {
-      this.showTotalNumberOfResults = false
       await this.find(JSON.parse(this.queryJson))
-      this.showTotalNumberOfResults = true
     }
   }
 }
@@ -37,7 +34,7 @@ export default {
       .record-views
         json-viewer(v-for="record in records" :value="record" theme="jv-dark")
     div.query-total-results
-      p(v-if="showTotalNumberOfResults") Total Results: {{totalNumberOfResults}}
+      p(v-if="totalNumberOfResults!= null") Total Results: {{totalNumberOfResults}}
 </template>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
 Issue #7 

Total number of results for the most recent query is displayed under records pane for each successful query by reading the length property of result array.

The issue statement describes the requirement for displaying the number of executions after each "successful query". I have some concerns if I should have checked the "successful query" in more detail, i.e. wrapping database query in a try catch block and passing error in case of a failure etc. For the moment, as long as `doQuery` method executes and returns, it is assumed that the query is executed successfully.

For accessing the total number of results, the length property of the result array is read, as this seemed the simplest way to do this to me. I'm thinking if there would be a case where it is needed or would be more efficient to get the total number of results via the database driver.