### PR TITLE
Use new URL parser instead of deprecated URL string parser

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -15,7 +15,7 @@ export default new Vuex.Store({
   mutations: {},
   actions: {
     async connect({ state, dispatch }, connectionString) {
-      await mongoose.connect(connectionString)
+      await mongoose.connect(connectionString, {useNewUrlParser: true})
       state.connection = mongoose.connection
       await dispatch('getCollections')
     },

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -15,7 +15,7 @@ export default new Vuex.Store({
   mutations: {},
   actions: {
     async connect({ state, dispatch }, connectionString) {
-      await mongoose.connect(connectionString, {useNewUrlParser: true})
+      await mongoose.connect(connectionString, { useNewUrlParser: true })
       state.connection = mongoose.connection
       await dispatch('getCollections')
     },


### PR DESCRIPTION
Resolves 'DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. To use the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.' warning.