### PR TITLE
Database listing functionality added 

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,19 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
       # Runs a single command using the runners shell
       - name: Install dependencies
         run: npm install

--- a/src/components/connections.vue
+++ b/src/components/connections.vue
@@ -13,14 +13,14 @@ export default {
     }
   },
   methods: {
-    ...mapActions(['connect', 'setCollection']),
+    ...mapActions(['connect', 'setDatabase', 'setCollection']),
     async doConnect() {
       await this.connect(this.connectionString)
       this.$router.push('/connection')
     }
   },
   computed: {
-    ...mapState(['collections'])
+    ...mapState(['databases', 'collections'])
   }
 }
 </script>
@@ -39,6 +39,10 @@ export default {
         p Connection string:
         input(type="text" v-model="connectionString")
       button(type="button" @click="doConnect") Connect
+  .box
+    h1 Databases
+    .database(v-for="database in databases" @click="setDatabase(database.name)")
+      p {{database.name}}
   .box
     h1 Collections
     .collection(v-for="collection in collections" @click="setCollection(collection.name)")

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -26,7 +26,7 @@ export default new Vuex.Store({
       state.totalNumberOfResults = null
       const collection = state.connection.db.collection(state.collectionName)
       const cursor = await collection.find(query)
-      cursor.count((err,result) => {
+      cursor.count((err, result) => {
         if (err) return
 
         state.totalNumberOfResults = result

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,8 +1,7 @@
 import Vue from 'vue'
 import Vuex from 'vuex'
 const mongoose = require('mongoose')
-const Admin = mongoose.mongo.Admin;
-
+const Admin = mongoose.mongo.Admin
 
 Vue.use(Vuex)
 
@@ -23,12 +22,11 @@ export default new Vuex.Store({
       state.connection = mongoose.connection
       await dispatch('getDatabases')
     },
-    async getDatabases({ state }){
-      try{
+    async getDatabases({ state }) {
+      try {
         let databaseList = await new Admin(state.connection.db).listDatabases()
         state.databases = databaseList.databases
-      }
-      catch (e) {
+      } catch (e) {
         console.log(e)
       }
     },
@@ -51,7 +49,7 @@ export default new Vuex.Store({
       state.databaseName = databaseName
       state.collectionName = ''
       state.records = []
-      await dispatch ('getCollections')
+      await dispatch('getCollections')
     },
     async setCollection({ state }, collectionName) {
       state.collectionName = collectionName

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,12 +1,16 @@
 import Vue from 'vue'
 import Vuex from 'vuex'
 const mongoose = require('mongoose')
+const Admin = mongoose.mongo.Admin;
+
 
 Vue.use(Vuex)
 
 export default new Vuex.Store({
   state: {
     connection: null,
+    databases: [],
+    databaseName: '',
     collections: [],
     records: [],
     collectionName: '',
@@ -17,7 +21,16 @@ export default new Vuex.Store({
     async connect({ state, dispatch }, connectionString) {
       await mongoose.connect(connectionString, { useNewUrlParser: true })
       state.connection = mongoose.connection
-      await dispatch('getCollections')
+      await dispatch('getDatabases')
+    },
+    async getDatabases({ state }){
+      try{
+        let databaseList = await new Admin(state.connection.db).listDatabases()
+        state.databases = databaseList.databases
+      }
+      catch (e) {
+        console.log(e)
+      }
     },
     async getCollections({ state }) {
       state.collections = await state.connection.db.listCollections().toArray()
@@ -32,6 +45,13 @@ export default new Vuex.Store({
         state.totalNumberOfResults = result
       })
       state.records = await cursor.toArray()
+    },
+    async setDatabase({ state, dispatch }, databaseName) {
+      state.connection = state.connection.useDb(databaseName)
+      state.databaseName = databaseName
+      state.collectionName = ''
+      state.records = []
+      await dispatch ('getCollections')
     },
     async setCollection({ state }, collectionName) {
       state.collectionName = collectionName

--- a/src/views/connection.vue
+++ b/src/views/connection.vue
@@ -9,7 +9,7 @@ export default {
     }
   },
   computed: {
-    ...mapState(['collectionName', 'records', 'totalNumberOfResults'])
+    ...mapState(['collectionName', 'databaseName', 'records', 'totalNumberOfResults'])
   },
   methods: {
     ...mapActions(['find']),
@@ -21,7 +21,7 @@ export default {
 </script>
 <template lang="pug">
   div.connection
-    h1 {{ collectionName }} collection
+    h1 {{ databaseName }} - {{ collectionName }} collection
     .box
       form
         .form-item

--- a/src/views/connection.vue
+++ b/src/views/connection.vue
@@ -5,7 +5,7 @@ export default {
   name: 'Connection',
   data() {
     return {
-      queryJson: '{}',
+      queryJson: '{}'
     }
   },
   computed: {


### PR DESCRIPTION
#9 Provides listing database functionality. Currently, switching a database requires opening a new connection (without closing the first one) and state points only one connection (second in this case). This causes having two connections open but with no reference to first one. Should be refactored once connection pooling is available.

Edit: It turns out that native mongodriver uses connection pooling under the hood and abstracted from the user when connecting with `mongoose.connect`, so the above comment is invalid. 